### PR TITLE
fix: Add Head component from Nextra to poperly setup layout

### DIFF
--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,4 +1,5 @@
 import { Footer, Layout, Navbar } from "nextra-theme-docs";
+import { Head } from "nextra/components";
 import { IBM_Plex_Sans as FontSans } from "next/font/google";
 import { getPageMap } from "nextra/page-map";
 import "nextra-theme-docs/style.css";
@@ -23,6 +24,7 @@ export default async function RootLayout({ children }) {
   const pageMap = await getPageMap();
   return (
     <html lang="de" dir="ltr" suppressHydrationWarning>
+      <Head />
       <body className={"font-sans antialiased " + fontSans.variable}>
         <Layout
           navbar={navbar}


### PR DESCRIPTION
# Description

This should fix the layout issues on mobile. Nextra wasn’t set up correctly because it needs the Head to be present. 

# Checklist:

- [x] I have read and agree to the projects [Code of Conduct](../CODE_OF_CONDUCT.md)
- [x] I have read and agree to publishing my contribution under the projects [Content License](../CONTENT_LICENSE.md). I am legally able to do so.
- [x] I have included the source of the information in my answer.
